### PR TITLE
Cambié texto en inglés que se leía en NVDA

### DIFF
--- a/_includes/social-share.html
+++ b/_includes/social-share.html
@@ -15,7 +15,7 @@
   {% if site.share-links-active.twitter %}
   <!--- Share on Twitter -->
     <a href="https://twitter.com/intent/tweet?text={{ page.title | url_encode }}+{{ site.url }}{{ page.url }}"
-      class="btn btn-social-icon btn-twitter" title="Share on Twitter">
+      class="btn btn-social-icon btn-twitter" title="Hacé click para compartir en Twitter">
       <span class="fa fa-fw fa-twitter" aria-hidden="true"></span>
       <span class="sr-only">Twitter</span>
     </a>
@@ -24,7 +24,7 @@
   {% if site.share-links-active.facebook %}
   <!--- Share on Facebook -->
     <a href="https://www.facebook.com/sharer/sharer.php?u={{ site.url }}{{ page.url }}"
-      class="btn btn-social-icon btn-facebook" title="Share on Facebook">
+      class="btn btn-social-icon btn-facebook" title="Hacé click para compartir en Facebook">
       <span class="fa fa-fw fa-facebook" aria-hidden="true"></span>
       <span class="sr-only">Facebook</span>
     </a>
@@ -33,7 +33,7 @@
   {% if site.share-links-active.google %}
   <!--- Share on Google Plus -->
     <a href="https://plus.google.com/share?url={{ site.url }}{{ page.url }}"
-      class="btn btn-social-icon btn-google" title="Share on Google+">
+      class="btn btn-social-icon btn-google" title="Hacé click para compartir en Google+">
       <span class="fa fa-fw fa-google-plus" aria-hidden="true"></span>
       <span class="sr-only">Google+</span>
     </a>
@@ -42,7 +42,7 @@
   {% if site.share-links-active.linkedin %}
   <!--- Share on LinkedIn -->
     <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ site.url }}{{ page.url }}"
-      class="btn btn-social-icon btn-linkedin" title="Share on LinkedIn">
+      class="btn btn-social-icon btn-linkedin" title="Hacé click para compartir en LinkedIn">
       <span class="fa fa-fw fa-linkedin" aria-hidden="true"></span>
       <span class="sr-only">LinkedIn</span>
     </a>


### PR DESCRIPTION
Cambié la frase "Share on", por "Hacé click para compartir en" en parte para que todo esté en Español, pero además porque el lector de pantalla pronunciaba "Sare" por lo cual podía prestarse a confusión para aquellos usuarios sin conocimientos en inglés.